### PR TITLE
Increase big osmosis local cache size

### DIFF
--- a/inaugurator/osmosiscleanup.py
+++ b/inaugurator/osmosiscleanup.py
@@ -7,18 +7,18 @@ import logging
 
 
 class OsmosisCleanup:
-    ALLOWED_DISK_USAGE_PERCENT = 66
+    ALLOWED_DISK_USAGE_PERCENT = 80
 
     def __init__(self, mountPoint, objectStorePath):
         self._objectStore = objectstore.ObjectStore(objectStorePath)
-        before = disk.dfPercent(mountPoint)
+        before = disk.dfPercent(objectStorePath)
         if self._objectStoreExists():
             self._attemptObjectStoreCleanup()
         logging.info("Disk usage: before cleanup: %(before)s%%, after: %(after)s%%", dict(
-            before=before, after=disk.dfPercent(mountPoint)))
-        if disk.dfPercent(mountPoint) > self.ALLOWED_DISK_USAGE_PERCENT:
+            before=before, after=disk.dfPercent(objectStorePath)))
+        if disk.dfPercent(objectStorePath) > self.ALLOWED_DISK_USAGE_PERCENT:
             logging.info("Erasing disk - osmosis cleanup did not help")
-            self._eraseEverything(mountPoint)
+            self._eraseEverything(objectStorePath)
 
     def _objectStoreExists(self):
         try:
@@ -34,5 +34,5 @@ class OsmosisCleanup:
         except cleanupremovelabelsuntildiskusage.ObjectStoreEmptyException:
             pass
 
-    def _eraseEverything(self, mountPoint):
-        sh.run("busybox rm -fr %s/*" % mountPoint)
+    def _eraseEverything(self, objectStorePath):
+        sh.run("busybox rm -fr %s/*" % objectStorePath)

--- a/inaugurator/partitiontable.py
+++ b/inaugurator/partitiontable.py
@@ -10,7 +10,7 @@ class PartitionTable:
         smallSwap=1,
         bigSwap=8,
         smallOsmosisCache=5,
-        bigOsmosisCache=15,
+        bigOsmosisCache=30,
         minimumRoot=7,
         createRoot=10)
     VOLUME_GROUP = "inaugurator"


### PR DESCRIPTION
@maor in context of Jira: IRS-185, and after further debug we see that there is code in the inaugurator for disk size  protection, when total disk size reach 66% the inaugurator code. the reason we see the out of disk for osmosis cache is because osmosis partition is << disk size. this simple fix increase the size of osmosis cache and practically avoid the problem in the related ticket  