### PR TITLE
Inagurator upgrade to kernel 4.11 and NVDIMM support

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -120,22 +120,15 @@ build/inaugurator.thin.initrd.dir: ${PYTHON_DIST_LOCAL_PATH} build/osmosis-1.0.l
 	echo "Copying drivers"
 	DEST=$@.tmp KERNEL_UNAME_R=$(KERNEL_VERSION) sh/relative_copy_driver.sh ixgbe
 	DEST=$@.tmp KERNEL_UNAME_R=$(KERNEL_VERSION) sh/relative_copy_driver.sh virtio_blk
-	DEST=$@.tmp KERNEL_UNAME_R=$(KERNEL_VERSION) sh/relative_copy_driver.sh isci
 	DEST=$@.tmp KERNEL_UNAME_R=$(KERNEL_VERSION) sh/relative_copy_driver.sh virtio_net
 	DEST=$@.tmp KERNEL_UNAME_R=$(KERNEL_VERSION) sh/relative_copy_driver.sh virtio_pci
 	DEST=$@.tmp KERNEL_UNAME_R=$(KERNEL_VERSION) sh/relative_copy_driver.sh e1000
 	DEST=$@.tmp KERNEL_UNAME_R=$(KERNEL_VERSION) sh/relative_copy_driver.sh igb
 	DEST=$@.tmp KERNEL_UNAME_R=$(KERNEL_VERSION) sh/relative_copy_driver.sh 8139cp
 	DEST=$@.tmp KERNEL_UNAME_R=$(KERNEL_VERSION) sh/relative_copy_driver.sh vfat
-	DEST=$@.tmp KERNEL_UNAME_R=$(KERNEL_VERSION) sh/relative_copy_driver.sh ext4
 	DEST=$@.tmp KERNEL_UNAME_R=$(KERNEL_VERSION) sh/relative_copy_driver.sh usb_storage
-	DEST=$@.tmp KERNEL_UNAME_R=$(KERNEL_VERSION) sh/relative_copy_driver.sh dm_mod
-	DEST=$@.tmp KERNEL_UNAME_R=$(KERNEL_VERSION) sh/relative_copy_driver.sh sd_mod
-	DEST=$@.tmp KERNEL_UNAME_R=$(KERNEL_VERSION) sh/relative_copy_driver.sh ahci
 	DEST=$@.tmp KERNEL_UNAME_R=$(KERNEL_VERSION) sh/relative_copy_driver.sh isofs
-	DEST=$@.tmp KERNEL_UNAME_R=$(KERNEL_VERSION) sh/relative_copy_driver.sh ata_piix
 	DEST=$@.tmp sh/relative_copy_glob.sh /lib/modules/$(KERNEL_VERSION)/modules.order
-	DEST=$@.tmp KERNEL_UNAME_R=$(KERNEL_VERSION) sh/relative_copy_driver.sh aacraid
 	DEST=$@.tmp sh/relative_copy_glob.sh /lib/modules/$(KERNEL_VERSION)/modules.builtin
 	depmod --basedir=$@.tmp $(KERNEL_VERSION)
 	echo "Misc"

--- a/Makefile.build
+++ b/Makefile.build
@@ -1,4 +1,4 @@
-KERNEL_VERSION = 3.10.0-514.6.1.el7.x86_64
+KERNEL_VERSION=4.11.4-200.fc25.x86_64
 INAUGURATOR_VERSION=$(shell python setup.py --version)
 
 KERNEL_IMAGE_PATH=define_build_host_msg

--- a/docker/build-inaugurator.dockerfile
+++ b/docker/build-inaugurator.dockerfile
@@ -1,23 +1,12 @@
-FROM centos:7.2.1511
+FROM fedora:25
 MAINTAINER eliran@stratoscale.com
 
-
-# Add the EPEL repository and update all packages
-RUN echo "80.239.156.215          mirrors.fedoraproject.org" >> /etc/hosts
-RUN echo "213.129.242.84          mirrors.rpmfusion.org" >> /etc/hosts
-
-
-RUN yum update -y
-
-# Add the EPEL repository and update all packages
-RUN curl http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm -o temp && \
-    rpm -ivh temp && \
-    rm temp
-
 # Install other tools
-RUN yum update -y
+RUN echo "fastmirror=True" >> /etc/dnf/dnf.conf
 
-RUN yum install -y \
+RUN dnf update -y
+
+RUN dnf install -y \
     sudo \
     boost-devel \
     boost-static \
@@ -34,18 +23,14 @@ RUN yum install -y \
     make \
     kernel \
     lshw \
-    rsync && \
-    yum -y clean all
+    rsync \
+    busybox && \
+    dnf -y clean all
 
 RUN pip install pep8 pika>=0.10.0
 
 # Edit sudoers file to avoid error: sudo: sorry, you must have a tty to run sudo
 RUN sed -i -e "s/Defaults    requiretty.*/ #Defaults    requiretty/g" /etc/sudoers
-
-# Install busybox with a Fedora RPM since there's no such package for Centos 7
-RUN curl ftp://195.220.108.108/linux/fedora/linux/releases/23/Everything/x86_64/os/Packages/b/busybox-1.22.1-4.fc23.x86_64.rpm -o temp && \
-    rpm -ivh temp && \
-    rm temp
 
 WORKDIR /root
 

--- a/inaugurator/partitiontable.py
+++ b/inaugurator/partitiontable.py
@@ -14,12 +14,12 @@ class PartitionTable:
         minimumRoot=7,
         createRoot=10)
     VOLUME_GROUP = "inaugurator"
-    LAYOUT_SCHEMES = dict(GPT=dict(partitions=dict(bios_boot=dict(sizeMB=2, flags="bios_grub"),
-                                                   boot=dict(sizeMB=256, fs="ext4", flags="boot"),
-                                                   lvm=dict(flags="lvm", sizeMB="fillUp")),
+    LAYOUT_SCHEMES = dict(GPT=dict(partitions=dict(bios_boot=dict(sizeMB=2, set_flags="bios_grub", flags="bios_grub"),
+                                                   boot=dict(sizeMB=256, fs="ext4", flags="boot, esp", set_flags="boot"),
+                                                   lvm=dict(set_flags="lvm", flags="lvm", sizeMB="fillUp")),
                                    order=("bios_boot", "boot", "lvm")),
-                          MBR=dict(partitions=dict(boot=dict(sizeMB=256, fs="ext4", flags="boot"),
-                                                   lvm=dict(flags="lvm", sizeMB="fillUp")),
+                          MBR=dict(partitions=dict(boot=dict(sizeMB=256, fs="ext4", set_flags="boot", flags="boot"),
+                                                   lvm=dict(set_flags="lvm", flags="lvm", sizeMB="fillUp")),
                                    order=("boot", "lvm")))
 
     def __init__(self, device, sizesGB=dict(), layoutScheme="GPT"):
@@ -111,7 +111,7 @@ class PartitionTable:
     def _setFlags(self):
         for partitionIdx, partition in enumerate(self._physicalPartitionsOrder):
             partitionNr = partitionIdx + 1
-            flag = self._physicalPartitions[partition]["flags"]
+            flag = self._physicalPartitions[partition]["set_flags"]
             print "Setting flag '%s' for partition #%d..." % (flag, partitionNr)
             sh.run("parted -s %s set %d %s on" % (self._device, partitionNr, flag))
 

--- a/sh/list_storage_and_network_driver_names.sh
+++ b/sh/list_storage_and_network_driver_names.sh
@@ -3,4 +3,4 @@
 BLACKLIST='-e bfa -e csiostor -e cxgb4 -e bna -e aic94xx'
 KERNEL_VERSION=$1
 set -e
-find /lib/modules/$KERNEL_VERSION/kernel/drivers/net/ethernet /lib/modules/$KERNEL_VERSION/kernel/drivers/scsi -type f -printf '%f\n' | sed 's/\.ko$//' | grep -v $BLACKLIST
+find /lib/modules/$KERNEL_VERSION/kernel/drivers/net/ethernet /lib/modules/$KERNEL_VERSION/kernel/drivers/scsi -type f -printf '%f\n' | sed 's/\.ko.xz$//' | grep -v $BLACKLIST

--- a/sh/relative_copy_driver.sh
+++ b/sh/relative_copy_driver.sh
@@ -5,7 +5,7 @@
 
 #Blacklist of firmware binaries not found in the distribution
 # See: http://www.spinics.net/lists/linux-scsi/msg85340.html
-FIRMWARE_BLACKLIST="-e ql2600_fw.bin -e ql2700_fw.bin -e ql8300_fw.bin"
+FIRMWARE_BLACKLIST="-e ql2600_fw.bin -e ql2700_fw.bin -e ql8300_fw.bin -e netronome -e wd719x"
 
 set -e
 for ko in `modprobe --show-depends $1 --set-version=$KERNEL_UNAME_R | sed 's/insmod //'`; do


### PR DESCRIPTION
Upgraded Inaugurator kernel to 4.11.Based on Fedora 25.

Original issue was: IRS-237/LBM1-1586 NVDIMM devices were not recognized after inauguration.
This required a new kexec version (see https://github.com/horms/kexec-tools/commit/cb9a818ff2ac437e76512ec01c0eb22d0d7456b2). As part of resolving additional issue, also upgraded the kernel version.