### PR TITLE
Add tg3 driver to support the new Tyan platform

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -6,21 +6,20 @@ INITRD_IMAGE_PATH=define_build_host_msg
 PYTHON_DIST_FILENAME=inaugurator-${INAUGURATOR_VERSION}.linux-x86_64.tar.gz
 PYTHON_DIST_LOCAL_PATH=dist/${PYTHON_DIST_FILENAME}
 ifeq ($(BUILD_HOST),local)
-KERNEL_IMAGE_PATH=/boot/vmlinuz-$(KERNEL_VERSION)
-INITRD_IMAGE_PATH=build/inaugurator.%.initrd.dir
-PYTHON_DIST_RECIPE=build_python_dist_locally
+	KERNEL_IMAGE_PATH=/boot/vmlinuz-$(KERNEL_VERSION)
+	INITRD_IMAGE_PATH=build/inaugurator.%.initrd.dir
+	PYTHON_DIST_RECIPE=build_python_dist_locally
 endif
 ifeq ($(BUILD_HOST),docker)
-KERNEL_IMAGE_PATH=docker-build/inaugurator.vmlinuz
-INITRD_IMAGE_PATH=docker-build/inaugurator.%.initrd.dir
-PYTHON_DIST_RECIPE=docker-dist/${PYTHON_DIST_FILENAME}
+	KERNEL_IMAGE_PATH=docker-build/inaugurator.vmlinuz
+	INITRD_IMAGE_PATH=docker-build/inaugurator.%.initrd.dir
+	PYTHON_DIST_RECIPE=docker-dist/${PYTHON_DIST_FILENAME}
 endif
 DOCKER_RUN_CMD=
 
 .PHONY: define_build_host_msg
 define_build_host_msg:
 	$(error Please specify the environment variable 'BUILD_HOST', to indicate where to build, as either 'local' (build images locally) or 'docker', (build images inside a docker container, which is better if the host does not have all the necessary packages).)
-
 
 .PHONY: build
 build: build/inaugurator.vmlinuz build/inaugurator.thin.initrd.img build/inaugurator.fat.initrd.img ${PYTHON_DIST_PATH}
@@ -42,7 +41,6 @@ docker-dist/${PYTHON_DIST_FILENAME}:
 	$(MAKE) build_container
 	sudo docker run --rm -v `pwd`:/root/inaugurator -v $(PWD)/docker-build:/root/inaugurator/build -v `pwd`/../osmosis:/root/osmosis -v $(PWD)/docker-dist:/root/inaugurator/dist build-inaugurator:$(INAUGURATOR_VERSION) dist/$(@F)
 	$(MAKE) chown_stuff
-
 
 build/inaugurator.vmlinuz: $(KERNEL_IMAGE_PATH)
 	-@mkdir $(@D)
@@ -68,7 +66,7 @@ build/inaugurator.%.initrd.img: $(INITRD_IMAGE_PATH)
 
 build/osmosis-1.0.linux-x86_64.tar.gz:
 	(cd ../osmosis/ && $(MAKE) clean && $(MAKE) build && $(MAKE) egg)
-	 cp ../osmosis/dist/osmosis-1.0.linux-x86_64.tar.gz $@
+	cp ../osmosis/dist/osmosis-1.0.linux-x86_64.tar.gz $@
 
 build/inaugurator.thin.initrd.dir: ${PYTHON_DIST_LOCAL_PATH} build/osmosis-1.0.linux-x86_64.tar.gz
 	-@mkdir build
@@ -156,9 +154,9 @@ build/build-inaugurator.dockerfile:
 
 .PHONY: build_container
 build_container: build/build-inaugurator.dockerfile
-ifeq ($(BUILD_HOST),docker)
-ifeq ($(shell sudo docker images | egrep -Ec "^build-inaugurator[ ]+$(INAUGURATOR_VERSION)" | xargs echo -n),0)
-	$(info It seems that a build-inaugurator image for version $(INAUGURATOR_VERSION) of Inaugurator was not built. Trying to build it....)
-	sudo docker build -f build/build-inaugurator.dockerfile -t build-inaugurator:$(INAUGURATOR_VERSION) build
-endif
-endif
+	ifeq ($(BUILD_HOST),docker)
+		ifeq ($(shell sudo docker images | egrep -Ec "^build-inaugurator[ ]+$(INAUGURATOR_VERSION)" | xargs echo -n),0)
+			$(info It seems that a build-inaugurator image for version $(INAUGURATOR_VERSION) of Inaugurator was not built. Trying to build it....)
+			sudo docker build -f build/build-inaugurator.dockerfile -t build-inaugurator:$(INAUGURATOR_VERSION) build
+		endif
+	endif

--- a/Makefile.build
+++ b/Makefile.build
@@ -22,7 +22,7 @@ define_build_host_msg:
 	$(error Please specify the environment variable 'BUILD_HOST', to indicate where to build, as either 'local' (build images locally) or 'docker', (build images inside a docker container, which is better if the host does not have all the necessary packages).)
 
 .PHONY: build
-build: build/inaugurator.vmlinuz build/inaugurator.thin.initrd.img build/inaugurator.fat.initrd.img ${PYTHON_DIST_PATH}
+build: build/inaugurator.vmlinuz build/inaugurator.thin.initrd.img ${PYTHON_DIST_PATH}
 
 .PHONY: build_python_dist_locally
 build_python_dist_locally:

--- a/Makefile.build
+++ b/Makefile.build
@@ -1,4 +1,4 @@
-KERNEL_VERSION=4.13.16-100.fc25.x86_64
+KERNEL_VERSION=4.16.7-200.fc27.x86_64
 INAUGURATOR_VERSION=$(shell python setup.py --version)
 
 KERNEL_IMAGE_PATH=define_build_host_msg
@@ -121,6 +121,7 @@ build/inaugurator.thin.initrd.dir: ${PYTHON_DIST_LOCAL_PATH} build/osmosis-1.0.l
 	DEST=$@.tmp KERNEL_UNAME_R=$(KERNEL_VERSION) sh/relative_copy_driver.sh virtio_net
 	DEST=$@.tmp KERNEL_UNAME_R=$(KERNEL_VERSION) sh/relative_copy_driver.sh virtio_pci
 	DEST=$@.tmp KERNEL_UNAME_R=$(KERNEL_VERSION) sh/relative_copy_driver.sh e1000
+	DEST=$@.tmp KERNEL_UNAME_R=$(KERNEL_VERSION) sh/relative_copy_driver.sh tg3
 	DEST=$@.tmp KERNEL_UNAME_R=$(KERNEL_VERSION) sh/relative_copy_driver.sh igb
 	DEST=$@.tmp KERNEL_UNAME_R=$(KERNEL_VERSION) sh/relative_copy_driver.sh 8139cp
 	DEST=$@.tmp KERNEL_UNAME_R=$(KERNEL_VERSION) sh/relative_copy_driver.sh vfat

--- a/Makefile.lb
+++ b/Makefile.lb
@@ -20,5 +20,4 @@ install_dir:
 checkin:
 	$(Q)component-tool checkin --repo=inaugurator --type=$(BUILD_TYPE) inaugurator
 
-
 .PHONY: install checkin clean build

--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ The Inaugurator depends on the latest Fedora kernel. You may need to scratch the
 To build:
     dockerize make -d Makefile.lb
 
-If this gets stuck on missing kernels, use `docker rmi fedora:25` and try again.
+If this gets stuck on missing kernels, use `docker rmi fedora:27` and try again.
 
 While it's running, note the version of the kernel RPM getting installed, and in a second terminal update that string into the first line of Makefile.build.

--- a/docker/build-inaugurator.dockerfile
+++ b/docker/build-inaugurator.dockerfile
@@ -1,5 +1,5 @@
-FROM fedora:25
-MAINTAINER eliran@stratoscale.com
+FROM fedora:27
+MAINTAINER ops@lightbitslabs.com
 
 # Install other tools
 RUN echo "fastmirror=True" >> /etc/dnf/dnf.conf

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def read(fname):
 
 setup(
     name="inaugurator",
-    version="1.3",
+    version="1.4",
     author="Shlomo Matichin",
     author_email="shlomomatichin@gmail.com",
     description=(


### PR DESCRIPTION
New machine comes with tg3 instead of e1000 and needed a kernel upgrade (tg3 was not in Fedora 25 for some reason).

New kernel is 4.16, works nice with everyone and comes with tg3.