### PR TITLE
update to the correct kernel version

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -1,4 +1,4 @@
-KERNEL_VERSION=4.16.11-200.fc27.x86_64
+KERNEL_VERSION=$(shell rpm -q kernel | cut -c8-)
 INAUGURATOR_VERSION=$(shell python setup.py --version)
 
 KERNEL_IMAGE_PATH=define_build_host_msg


### PR DESCRIPTION
I need to do a bit more tests.
but this is working because when we need the kernel version we are already in the fedora docker, we can just check what is inside the /boot