### PR TITLE
ceremony: empty boot before rsync the new content into it

### DIFF
--- a/inaugurator/ceremony.py
+++ b/inaugurator/ceremony.py
@@ -181,6 +181,7 @@ class Ceremony:
 
     def _createBootAndInstallGrub(self, destination):
         with self._mountOp.mountBoot() as bootDestination:
+            sh.run("rm -rf %s/*; sync" % bootDestination) # LBM1-4920
             sh.run("rsync -rlpgDS --delete-before %s/boot/ %s/" % (destination, bootDestination))
         with self._mountOp.mountBootInsideRoot():
             serialDevices = self._getSerialDevices()


### PR DESCRIPTION
/boot partition is 256MB.
ceremony.py:_createBootAndInstallGrub() does
rsync -rlpgDS --delete-before new-boot /boot

When the actual /boot content is below 128MB (actual ~64MB) all is fine.
However when both old and new /boot content are larger than 128MB
SOMETIMES we fail:
Command '('rsync -rlpgDS --delete-before /destRoot/boot/ /destBoot/',)' failed: 11
rsync: write failed on "/destBoot/vmlinux-4.14.47-da20782e8518-rel-lb.bz2": No space left on device (28)

This can be reproduced with a loop devices mapped to a 256MB file.

Solution: explicitely remove all /boot contents before rsync'ing the new stuff.

Now it looks like this:
	Executing Command: /usr/sbin/busybox mkdir -p /destBoot
	Executing Command: /usr/sbin/busybox mount -t ext4  /dev/sda2 /destBoot
-->	Executing Command: rm -rf /destBoot/*; sync
	Executing Command: rsync -rlpgDS --delete-before /destRoot/boot/ /destBoot/
	Executing Command: /usr/sbin/busybox umount /destBoot
	Executing Command: /usr/sbin/busybox mount -t ext4 /dev/sda2 /destRoot/boot
	[  317.420300] EXT4-fs (sda2): mounted filesystem with ordered data mode. Opts: (null)

Issue: LBM1-4920

Signed-off-by: Anton Eidelman <anton@lightbitslabs.com>