### PR TITLE
ifconfig lo to fix open socket failure with newer pika

### DIFF
--- a/inaugurator/network.py
+++ b/inaugurator/network.py
@@ -11,6 +11,7 @@ class Network:
         interfacesTable = self._interfacesTable()
         assert macAddress.lower() in interfacesTable, "macAddress %s interfacesTable %s" % (macAddress, interfacesTable)
         interfaceName = interfacesTable[macAddress.lower()]
+        sh.run("/usr/sbin/ifconfig lo 127.0.0.1")
         sh.run("/usr/sbin/ifconfig %s %s netmask %s" % (interfaceName, ipAddress, netmask))
         sh.run("busybox route add default gw %s" % self._gateway)
         self._validateLinkIsUp()


### PR DESCRIPTION
New pika (06/2018) fails to bind(host, 0) where host
is set to 127.0.0.1, see calltrace below.

Fix: ifconfig lo 127.0.0.1

2018-06-21 21:59:17,841 - root - ERROR - Failed to osmosis from source
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/inaugurator/ceremony.py", line 336, in _doOsmosisFromSource
    self._doOsmosisFromSourceUnsafe(destination)
  File "/usr/lib/python2.7/site-packages/inaugurator/ceremony.py", line 347, in _doOsmosisFromSourceUnsafe
    self._osmosFromNetwork(destination)
  File "/usr/lib/python2.7/site-packages/inaugurator/ceremony.py", line 212, in _osmosFromNetwork
    amqpURL=self._args.inauguratorServerAMQPURL, myID=self._args.inauguratorMyIDForServer)
  File "/usr/lib/python2.7/site-packages/inaugurator/talktoserver.py", line 121, in __init__
    self._spooler = TalkToServerSpooler(amqpURL, statusExchange, labelExchange)
  File "/usr/lib/python2.7/site-packages/inaugurator/talktoserver.py", line 21, in __init__
    self._connect(amqpURL)
  File "/usr/lib/python2.7/site-packages/inaugurator/talktoserver.py", line 55, in _connect
    self._connection = pika.BlockingConnection(parameters)
  File "/usr/lib/python2.7/site-packages/pika/adapters/blocking_connection.py", line 373, in __init__
    stop_ioloop_on_close=False)
  File "/usr/lib/python2.7/site-packages/pika/adapters/select_connection.py", line 88, in __init__
    ioloop = custom_ioloop or IOLoop()
  File "/usr/lib/python2.7/site-packages/pika/adapters/select_connection.py", line 298, in __init__
    self.process_timeouts)
  File "/usr/lib/python2.7/site-packages/pika/adapters/select_connection.py", line 334, in _get_poller
    poller = EPollPoller(**kwargs)
  File "/usr/lib/python2.7/site-packages/pika/adapters/select_connection.py", line 1085, in __init__
    super(PollPoller, self).__init__(get_wait_seconds, process_timeouts)
  File "/usr/lib/python2.7/site-packages/pika/adapters/select_connection.py", line 541, in __init__
    self._r_interrupt, self._w_interrupt = self._get_interrupt_pair()
  File "/usr/lib/python2.7/site-packages/pika/adapters/select_connection.py", line 840, in _get_interrupt_pair
    return pika.compat._nonblocking_socketpair() # pylint: disable=W0212
  File "/usr/lib/python2.7/site-packages/pika/compat.py", line 191, in _nonblocking_socketpair
    lsock.bind((host, 0))
  File "/usr/lib64/python2.7/socket.py", line 228, in meth
    return getattr(self._sock,name)(*args)
error: [Errno 99] Cannot assign requested address

Note: the latest inaugurator build also has kernel 4.16.15-200.fc27.x86_64
compared to 4.16.13-200.fc27.x86_64, but this is unlikely the reason for this issue.

Issue: LBM1-4933

Signed-off-by: Anton <anton@lightbitslabs.com>