### PR TITLE
inaugurator: start telnetd on inaugurator start

### DIFF
--- a/init
+++ b/init
@@ -3,6 +3,9 @@ export PATH=/bin:/usr/bin:/sbin:/usr/sbin
 /usr/sbin/busybox mount -t proc proc /proc
 /usr/sbin/busybox mount -t sysfs sys /sys
 /usr/sbin/busybox mdev -s
+/usr/sbin/mkdir -p /dev/pts
+/usr/sbin/busybox mount -t devpts none /dev/pts
+/usr/sbin/telnetd -l /bin/bash
 echo ifconfig -a:
 /usr/sbin/ifconfig -a
 /usr/sbin/busybox modprobe virtio_blk


### PR DESCRIPTION
in order to debug inaugurator system and examine hardware of the system
in inauguration stage we want telnet access to the system, so be the telnet
telnet is chosen and not ssh as telnet is already installed within the inaugurator.
@yuval-lb  you requested this change .. so be it 