### PR TITLE
change the order of actions, loading devices before getting info

### DIFF
--- a/inaugurator/hwinfo.py
+++ b/inaugurator/hwinfo.py
@@ -143,9 +143,9 @@ class HWinfo:
         data = {"network": get_network(),
                 "cpu": get_cpus(),
                 "ssd": get_ssds(),
+                "nvme_list": get_nvme_list(),  # runs mdev -s
                 "memory": get_dimm(),
                 "nvdimm": get_nvdimm(),
-                "nvme_list": get_nvme_list(),
                 "loaded_nvme_dev": get_loaded_nvme_devices(),
                 "lightfield": {
                     "numa0": get_lightfield(0),


### PR DESCRIPTION
the order could effect the ntdctl results - nvdimm information can be missing if not loaded before.
rack02-server52 for example.