### PR TITLE
Adding ssh support in inaugurator

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -88,7 +88,8 @@ build/inaugurator.thin.initrd.dir: ${PYTHON_DIST_LOCAL_PATH} build/osmosis-1.0.l
 	DEST=$@.tmp sh/relative_copy_glob.sh /usr/lib64/python2.7/lib-dynload/*
 	DEST=$@.tmp sh/relative_copy_executable.sh /usr/lib64/python2.7/lib-dynload/_hashlib.so
 	DEST=$@.tmp sh/relative_copy_executable.sh /usr/lib64/libudev.so.1
-	DEST=$@.tmp sh/relative_copy_glob.sh /usr/lib64/libnss_dns*
+	DEST=$@.tmp sh/relative_copy_glob.sh /usr/lib64/libtommath*
+	DEST=$@.tmp sh/relative_copy_glob.sh /usr/lib64/libnss_*
 	DEST=$@.tmp sh/relative_copy_glob.sh /usr/share/hwdata/pci.ids
 	echo "Copying pika:"
 	DEST=$@.tmp sh/relative_copy_glob.sh /usr/lib/python2.7/site-packages/pika/*.py
@@ -113,6 +114,7 @@ build/inaugurator.thin.initrd.dir: ${PYTHON_DIST_LOCAL_PATH} build/osmosis-1.0.l
 	DEST=$@.tmp sh/relative_copy_executable.sh /usr/sbin/chroot
 	DEST=$@.tmp sh/relative_copy_executable.sh /usr/sbin/dosfslabel
 	DEST=$@.tmp sh/relative_copy_executable.sh /usr/sbin/lvm
+	DEST=$@.tmp sh/relative_copy_executable.sh /usr/sbin/dropbear
 	DEST=$@.tmp sh/relative_copy_executable.sh /usr/sbin/lvmetad
 	DEST=$@.tmp sh/relative_copy_executable.sh /usr/sbin/fsck.ext4
 	DEST=$@.tmp sh/relative_copy_executable.sh /usr/bin/ndctl
@@ -151,6 +153,7 @@ build/inaugurator.thin.initrd.dir: ${PYTHON_DIST_LOCAL_PATH} build/osmosis-1.0.l
 	depmod --basedir=$@.tmp $(KERNEL_VERSION)
 	echo "Misc"
 	DEST=$@.tmp sh/relative_copy_glob.sh etc/*
+	DEST=$@.tmp sh/relative_copy_glob.sh etc/dropbear/*
 	DEST=$@.tmp sh/relative_copy_glob.sh init
 	mkdir -p $@.tmp/run/udev
 	mkdir -p $@.tmp/run/lvm

--- a/docker/build-inaugurator.dockerfile
+++ b/docker/build-inaugurator.dockerfile
@@ -26,6 +26,7 @@ RUN dnf install -y \
     pciutils \
     rsync \
     ndctl \
+    dropbear \
     busybox && \
     dnf -y clean all
 

--- a/etc/passwd
+++ b/etc/passwd
@@ -1,1 +1,1 @@
-root::0:0:root::
+root::0:0:root:/root:/bin/bash

--- a/etc/shells
+++ b/etc/shells
@@ -1,0 +1,2 @@
+/bin/sh
+/bin/bash

--- a/init
+++ b/init
@@ -6,6 +6,7 @@ export PATH=/bin:/usr/bin:/sbin:/usr/sbin
 /usr/sbin/mkdir -p /dev/pts
 /usr/sbin/busybox mount -t devpts none /dev/pts
 /usr/sbin/telnetd -l /bin/bash
+/usr/sbin/dropbear -R
 echo ifconfig -a:
 /usr/sbin/ifconfig -a
 /usr/sbin/busybox modprobe virtio_blk
@@ -23,4 +24,6 @@ wait
 echo lsmod:
 /usr/sbin/busybox lsmod
 export PYUDEV_UDEV_LIBRARY_NAME=libudev.so.1
+echo -e "light\nlight" | passwd root
+echo "export PATH=/bin:/usr/bin:/sbin:/usr/sbin" > /root/.bash_profile
 exec /bin/python2.7 -m inaugurator.main


### PR DESCRIPTION
ssh will be supported by using dropbear https://matt.ucc.asn.au/dropbear/dropbear.html
to do so the following has been changed:
Makefile.build - importing new libs and executable required by dropbear + adding dummy file under /etc/dropbear (required for auth keys)
/docker/build-inaugurator.dockerfile - adding the installation of dropbear during docker build
passwd - adding root home dir and shell
shells - allowed shells in the system (required to allow login to the system)
init - starting dropbear  + setting root password + setting root PATH environment variable