### PR TITLE
Proposed change to inaugurator to test SSD IOPS

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -116,6 +116,7 @@ build/inaugurator.thin.initrd.dir: ${PYTHON_DIST_LOCAL_PATH} build/osmosis-1.0.l
 	DEST=$@.tmp sh/relative_copy_executable.sh /usr/sbin/lvmetad
 	DEST=$@.tmp sh/relative_copy_executable.sh /usr/sbin/fsck.ext4
 	DEST=$@.tmp sh/relative_copy_executable.sh /usr/bin/ndctl
+	DEST=$@.tmp sh/relative_copy_executable.sh /usr/bin/fio
 	DEST=$@.tmp sh/relative_copy_executable.sh /usr/bin/numactl
 	DEST=$@.tmp sh/relative_copy_executable.sh /usr/bin/rsync
 	DEST=$@.tmp sh/relative_copy_executable.sh /usr/sbin/nvme

--- a/docker/build-inaugurator.dockerfile
+++ b/docker/build-inaugurator.dockerfile
@@ -25,6 +25,7 @@ RUN dnf install -y \
     lshw \
     pciutils \
     rsync \
+    fio \
     ndctl \
     numactl \
     busybox && \

--- a/inaugurator/hwinfo.py
+++ b/inaugurator/hwinfo.py
@@ -22,6 +22,13 @@ def get_nvdimm():
     except Exception as e:
         return []
 
+def get_fio():
+    try:
+        r = sh.run('fio --name=randwrite --ioengine=libaio --iodepth=1 --rw=randwrite --bs=4k --direct=1 --numjobs=1 --size=10m --time_base=1 --runtime=10 --group_reporting --filename=/destRoot/fio_test --output-format=json')
+        return json.loads(r)
+    except Exception as e:
+        {'error': e.message, 'command': sh.run('fio --name=randwrite --ioengine=libaio --iodepth=1 --rw=randwrite --bs=4k --direct=1 --numjobs=1 --size=10m --time_base=1 --runtime=10 --group_reporting --filename=/destRoot/fio_test --output-format=json')}
+
 
 def get_nvme_list():
     def load_nvme_devices():
@@ -163,6 +170,7 @@ class HWinfo:
     def run(self):
         data = {
                 "cpu": get_cpus(),
+                "fio": get_fio(),
                 "nvme_list": get_nvme_list(),  # runs mdev -s
                 "lshw": get_lshw(),
                 "ssd_per_numa": get_ssd_per_numa(),


### PR DESCRIPTION
1. installing fio in docker
2. add fio and dependencies
3. run fio test during H\W test and export it to selftest

Signed-off-by: Dror Vangosh <dror@lightbitslabs.com>