### PR TITLE
Yuval/hypervisor oriented

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -67,9 +67,10 @@ build/inaugurator.%.initrd.img: $(INITRD_IMAGE_PATH)
 	mv $@.tmp $@
 
 build/osmosis-1.0.linux-x86_64.tar.gz:
-	(cd ../osmosis/ && $(MAKE) clean && $(MAKE) build && $(MAKE) egg)
-	 cp ../osmosis/dist/osmosis-1.0.linux-x86_64.tar.gz $@
-
+	if  test ! -f ../osmosis/build/cpp/osmosis.bin ; then\
+		(cd ../osmosis/ && $(MAKE) clean && $(MAKE) build && $(MAKE) egg);\
+	fi
+	cp ../osmosis/dist/osmosis-1.0.linux-x86_64.tar.gz $@;
 build/inaugurator.thin.initrd.dir: ${PYTHON_DIST_LOCAL_PATH} build/osmosis-1.0.linux-x86_64.tar.gz
 	-@mkdir build
 	-rm -fr $@.tmp $@

--- a/inaugurator/ceremony.py
+++ b/inaugurator/ceremony.py
@@ -76,6 +76,7 @@ class Ceremony:
         inauguratorNetmask
         inauguratorGateway
         inauguratorSelfTestServerUrl - the url (ip+port) for self test server example: 192.168.70.66:50007
+        hypervisor - most of disk size will be under inaugurator--v%d-root
         """
         self._args = args
         self._talkToServer = None
@@ -157,7 +158,7 @@ class Ceremony:
         logging.info("Target device is %(device)s layout=%(layout)s",
                      dict(device=self._targetDevice, layout=self._args.inauguratorPartitionLayout))
         partitionTable = partitiontable.PartitionTable(self._targetDevice,
-                                                       layoutScheme=self._args.inauguratorPartitionLayout)
+                                                       layoutScheme=self._args.inauguratorPartitionLayout, hypervisor=self._args.hypervisor)
         if self._args.inauguratorClearDisk:
             partitionTable.clear()
         partitionTable.verify()

--- a/inaugurator/main.py
+++ b/inaugurator/main.py
@@ -38,6 +38,7 @@ parser.add_argument("--inauguratorExpectedLabel")
 parser.add_argument("--inauguratorPdbOnError", action="store_true", default=False)
 parser.add_argument("--inauguratorPartitionLayout", default="GPT")
 parser.add_argument("--inauguratorSelfTestServerUrl", default="192.168.66.70:50007")
+parser.add_argument("--hypervisor", action="store_true", default=False)
 
 
 def getArgsSource():


### PR DESCRIPTION
1. refactor makefile not build osmosis everytime - save a lot of time in inaugurator creation
2. adding --hypervisor flag to make root partition big as possible (dont waste on osmosis/etcd)