### PR TITLE
allow make fat inaugurator version

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -23,7 +23,7 @@ define_build_host_msg:
 
 
 .PHONY: build
-build: build/inaugurator.vmlinuz build/inaugurator.thin.initrd.img ${PYTHON_DIST_PATH}
+build: build/inaugurator.vmlinuz build/inaugurator.fat.initrd.img ${PYTHON_DIST_PATH}
 
 .PHONY: build_python_dist_locally
 build_python_dist_locally:

--- a/docker/build-inaugurator.dockerfile
+++ b/docker/build-inaugurator.dockerfile
@@ -40,8 +40,7 @@ WORKDIR /root
 
 CMD make -C osmosis build -j 10 && \
     make -C osmosis egg
-
-RUN rpm -i https://rpmfind.net/linux/fedora/linux/releases/29/Everything/x86_64/os/Packages/n/nvme-cli-1.6-1.fc29.x86_64.rpm
+RUN rpm -i https://rpmfind.net/linux/fedora/linux/releases/30/Everything/x86_64/os/Packages/n/nvme-cli-1.7-1.fc30.x86_64.rpm
 
 WORKDIR /root/inaugurator
 ENV BUILD_HOST local

--- a/sh/list_storage_and_network_driver_names.sh
+++ b/sh/list_storage_and_network_driver_names.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #list the drivers for the fat version
-BLACKLIST='-e bfa -e csiostor -e cxgb4 -e bna -e aic94xx'
+BLACKLIST='-e bfa -e csiostor -e cxgb4 -e bna -e aic94xx -e mlx4_core -e mlx4_en -e cxgb3'
 KERNEL_VERSION=$1
 set -e
 find /lib/modules/$KERNEL_VERSION/kernel/drivers/net/ethernet /lib/modules/$KERNEL_VERSION/kernel/drivers/scsi -type f -printf '%f\n' | sed 's/\.ko.xz$//' | grep -v $BLACKLIST


### PR DESCRIPTION
Here are the changes needed in case we want to create the fat inaugurator version. this was made for server 02-83 which uses qlogic nic.

I am not merging it for now, if we see this need to be the standard, I will merge.