### PR TITLE
inaugurator - add timeout for osmosis checkout

### DIFF
--- a/inaugurator/ceremony.py
+++ b/inaugurator/ceremony.py
@@ -26,7 +26,7 @@ import logging
 import threading
 import json
 import requests
-
+import signal
 
 class Ceremony:
 
@@ -336,17 +336,24 @@ class Ceremony:
             grubConfig=self._grubConfig,
             bootPath=os.path.join(destination, "boot"), rootPartition=self._mountOp.rootPartition())
 
-    def _doOsmosisFromSource(self, destination):
+    def _doOsmosisFromSource(self, destination, timeout_after = 20*60): #20 mins timeout
         cleanup = osmosiscleanup.OsmosisCleanup(destination, objectStorePath=self._localObjectStore)
+        signal.signal(signal.SIGALRM, self._raise_timeout_exception)
+        signal.alarm(timeout_after)
         try:
             self._doOsmosisFromSourceUnsafe(destination)
         except Exception as e:
-            logging.exception("Failed to osmosis from source")
+            logging.exception("Failed to osmosis from source. %(type)s, %(msg)s", dict(type=type(e), msg=e.message))
             cleanup.eraseEverything()
             sh.run("busybox rm -fr %s/*" % destination)
             if self._talkToServer:
                 self._talkToServer.progress(dict(state='warning', message=str(e)))
             self._doOsmosisFromSourceUnsafe(destination)
+        finally:
+            signal.alarm(0)
+
+    def _raise_timeout_exception(signum, frame, args = None):
+        raise Exception('Timeout')
 
     def _doOsmosisFromSourceUnsafe(self, destination):
         if self._args.inauguratorSource == 'network':


### PR DESCRIPTION
add timeout using SIGNAL in `_doOsmosisFromSource` and re-run after cleanup

**The fix**
This fix will trigger timeout in case _doOsmosisFromSource (osmosis checkout) is taking more than 20 mins.
After that, it will retry check-out once again after osmosis cleanup.

**Tests**
I have mocked timeout using `timeout.sleep()`:

```
while True:  
                print("sleeping")  
                time.sleep(1) 
``` 

And it successfully exited the infinite loop and moved on to osmosis cleanup.

**Issue:** 16841
Signed-off-by: Yan <yan@lightbitslabs.com>