### PR TITLE
add osmosis to pythonpath

### DIFF
--- a/inaugurator/main.py
+++ b/inaugurator/main.py
@@ -1,3 +1,10 @@
+
+# Need to make sure osmosis is installed
+import pkgutil
+if pkgutil.find_loader('osmosis') is None:
+    import sys
+    sys.path.append('/usr/local/lib/python2.7/dist-packages')
+
 from inaugurator import ceremony
 import argparse
 import traceback


### PR DESCRIPTION
osmosis package full path is archived in tar.gz format: /usr/local/lib/python2.7/dist-packages/osmosis

the new inaugurator can't locate it due to a different path created. old inaugurator uses /usr/lib/python2.7/site-packages/osmosis

fixup: add osmosis path dynamically